### PR TITLE
Wrong minSdkVersion value in sample apps

### DIFF
--- a/coordinators-sample-basic/build.gradle
+++ b/coordinators-sample-basic/build.gradle
@@ -7,7 +7,7 @@ android {
   defaultConfig {
     applicationId "com.squareup.coordinators.sample.basic"
 
-    minSdkVersion rootProject.ext.compileSdkVersion
+    minSdkVersion rootProject.ext.minSdkVersion
     versionName VERSION_NAME
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
   }

--- a/coordinators-sample-container/build.gradle
+++ b/coordinators-sample-container/build.gradle
@@ -7,7 +7,7 @@ android {
   defaultConfig {
     applicationId "com.squareup.coordinators.sample.root_layout"
 
-    minSdkVersion rootProject.ext.compileSdkVersion
+    minSdkVersion rootProject.ext.minSdkVersion
     versionName VERSION_NAME
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
   }


### PR DESCRIPTION
I am not sure if it's on purpose, I think that sample apps' minSdkVersion should use the minSdkVersion value instead of compileSdkVersion ? 