### PR TITLE
Bump minSdk in one sample to 21

### DIFF
--- a/coordinators-sample-container/build.gradle
+++ b/coordinators-sample-container/build.gradle
@@ -7,7 +7,7 @@ android {
   defaultConfig {
     applicationId "com.squareup.coordinators.sample.root_layout"
 
-    minSdkVersion rootProject.ext.minSdkVersion
+    minSdkVersion 21 // needed for <tag> in the layout files in this sample.
     versionName VERSION_NAME
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
   }


### PR DESCRIPTION
Closes #16 

The "container" sample relies on `<tag>` elements in its layout XML to
associate views with their Coordinators.  This sample had its minSdk set
to the project minSdk (15), but `<tag>` didn't appear until 21, so that
was just broken.

This isn't the only (or even necessarily the best) way to associate
views and Coordinators. This sample is just meant to illustrate that
there's more than one way to do it. If you need to support earlier API
levels, you'll need to come up with another mapping scheme.