### PR TITLE
Fix bind's overeagerness, tighten invariants

### DIFF
--- a/coordinators/build.gradle
+++ b/coordinators/build.gradle
@@ -17,6 +17,7 @@ android {
 
 dependencies {
   compile 'com.android.support:support-annotations:23.3.0'
+  compile 'com.android.support:support-v4:23.3.0'
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/coordinators/src/main/java/com/squareup/coordinators/Binding.java
+++ b/coordinators/src/main/java/com/squareup/coordinators/Binding.java
@@ -21,7 +21,6 @@ import android.view.View;
 final class Binding implements View.OnAttachStateChangeListener {
   private final Coordinator coordinator;
   private final View view;
-  private View attached;
 
   Binding(Coordinator coordinator, View view) {
     this.coordinator = coordinator;
@@ -29,24 +28,26 @@ final class Binding implements View.OnAttachStateChangeListener {
   }
 
   @Override public void onViewAttachedToWindow(@NonNull View v) {
-    if (v != attached) {
-      attached = v;
-      if (coordinator.isAttached()) {
-        throw new IllegalStateException(
-            "Coordinator " + coordinator + " is already attached to a View");
-      }
-      coordinator.setAttached(true);
-      coordinator.attach(view);
-      view.setTag(R.id.coordinator, coordinator);
+    if (v != view) {
+      throw new AssertionError("Binding for view " + view
+          + " notified of attachment of different view " + v);
     }
+    if (coordinator.isAttached()) {
+      throw new IllegalStateException(
+          "Coordinator " + coordinator + " is already attached");
+    }
+    coordinator.setAttached(true);
+    coordinator.attach(view);
+    view.setTag(R.id.coordinator, coordinator);
   }
 
   @Override public void onViewDetachedFromWindow(@NonNull View v) {
-    if (v == attached) {
-      attached = null;
-      coordinator.detach(view);
-      coordinator.setAttached(false);
-      view.setTag(R.id.coordinator, null);
+    if (v != view) {
+      throw new AssertionError("Binding for view " + view
+          + " notified of detachment of different view " + v);
     }
+    coordinator.detach(view);
+    coordinator.setAttached(false);
+    view.setTag(R.id.coordinator, null);
   }
 }

--- a/coordinators/src/main/java/com/squareup/coordinators/Coordinators.java
+++ b/coordinators/src/main/java/com/squareup/coordinators/Coordinators.java
@@ -19,6 +19,8 @@ import android.support.annotation.Nullable;
 import android.view.View;
 import android.view.ViewGroup;
 
+import static android.support.v4.view.ViewCompat.isAttachedToWindow;
+
 public final class Coordinators {
   private Coordinators() {
   }
@@ -40,7 +42,9 @@ public final class Coordinators {
     // Sometimes we missed the first attach because the child's already been added.
     // Sometimes we didn't. The binding keeps track to avoid double attachment of the Coordinator,
     // and to guard against attachment to two different views simultaneously.
-    binding.onViewAttachedToWindow(view);
+    if (isAttachedToWindow(view)) {
+      binding.onViewAttachedToWindow(view);
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #18 

After creating a Binding, Coordinators.bind would immediately call its
`onViewAttachedToWindow`, without regard for whether that was true.

The idea was to eliminate a potential race, where `bind` was called
after the View was already attached to the Window. When that happened the
Binding wouldn't be called by the platform, so the Coordinator would
never learn that it was attached unless `bind` called it directly.

That implementation created a problem though: If the View was _not_
already attached to the Window, the Coordinator would still receive an
`attach` call. This violated expectations around the interaction between
Coordinator and View lifecycle. Technically that was fine, because no
promises were made; but it was still surprising.

With this change, `bind` will still call `onAttachedToWindow` but _only_
if the View actually is already attached. This should alleviate any
confusion.

As a side effect, there's also no longer any potential for a duplicate
`onAttachedToWindow` call. This means we can tighten up the assertions
in the Binding. I also took the opportunity to tighten up all of the
assertions in Binding, so now it enforces a very strict 1:1:1
relationship between the Binding, View, and Coordinator and fails loudly
if that invariant is violated.