### PR TITLE
remove appsupport-v4 dependency

### DIFF
--- a/coordinators/build.gradle
+++ b/coordinators/build.gradle
@@ -17,7 +17,6 @@ android {
 
 dependencies {
   compile 'com.android.support:support-annotations:23.3.0'
-  compile 'com.android.support:support-v4:23.3.0'
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/coordinators/src/main/java/com/squareup/coordinators/Coordinators.java
+++ b/coordinators/src/main/java/com/squareup/coordinators/Coordinators.java
@@ -15,11 +15,10 @@
  */
 package com.squareup.coordinators;
 
+import android.os.Build;
 import android.support.annotation.Nullable;
 import android.view.View;
 import android.view.ViewGroup;
-
-import static android.support.v4.view.ViewCompat.isAttachedToWindow;
 
 public final class Coordinators {
   private Coordinators() {
@@ -61,5 +60,13 @@ public final class Coordinators {
 
   @Nullable public static Coordinator getCoordinator(View view) {
     return (Coordinator) view.getTag(R.id.coordinator);
+  }
+
+  private static boolean isAttachedToWindow(View view) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
+      return view.getWindowToken() != null;
+    } else {
+      return view.isAttachedToWindow();
+    }
   }
 }


### PR DESCRIPTION
We were only using appsupport-v4 for its View.isAttachedToWindow helper.
I took a peek at its implementation and implemented the same behavior
here (just a bit simplified).