### PR TITLE
Made Coordinators.bind() return the result from the provider.

### DIFF
--- a/coordinators/src/main/java/com/squareup/coordinators/Coordinators.java
+++ b/coordinators/src/main/java/com/squareup/coordinators/Coordinators.java
@@ -29,11 +29,13 @@ public final class Coordinators {
    *
    * Immediately calls provider to obtain a Coordinator for the view. If a non-null Coordinator is
    * returned, that Coordinator is permanently bound to the View.
+   *
+   * @return The value returned from the provider.
    */
-  public static void bind(View view, CoordinatorProvider provider) {
+  @Nullable public static Coordinator bind(View view, CoordinatorProvider provider) {
     final Coordinator coordinator = provider.provideCoordinator(view);
     if (coordinator == null) {
-      return;
+      return null;
     }
 
     View.OnAttachStateChangeListener binding = new Binding(coordinator, view);
@@ -44,6 +46,8 @@ public final class Coordinators {
     if (isAttachedToWindow(view)) {
       binding.onViewAttachedToWindow(view);
     }
+
+    return coordinator;
   }
 
   /**


### PR DESCRIPTION
This lets clients that want to hang on to the coordinator get a reference
to it without having to wrap the provider.